### PR TITLE
메세지에서 친구 선택 후 친구 명단 사라지는 문제 해결

### DIFF
--- a/MeetU2/src/com/test/controller/MessageController.java
+++ b/MeetU2/src/com/test/controller/MessageController.java
@@ -39,7 +39,7 @@ public class MessageController
 
 		String id = request.getParameter("friendId");
 
-		return "/WEB-INF/view/message/messageSendForm.jsp?friendId=" + id;
+		return "/messagesendform.action?friendId=" + id;
 	}
 
 	@RequestMapping(value = "/messageHostPick.action", method = RequestMethod.GET)


### PR DESCRIPTION
그룹 리스트도 동시에 해결됨

친구 선택 후 컨트롤러에서 action으로 메세지 보내는 폼을 불러온 것이 아니라서
리스트들을 가져오지 못했음